### PR TITLE
created image pop-up for card name mouseover

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -37,8 +37,8 @@ function App() {
           </div>
         </BrowserRouter>
         <div className='disclaimer'>
-          <hr className={'text-light'} />
-          <Col className={'m-auto text-center text-light pb-2'} lg='6'>
+          <hr className={mode === 'light' ? 'text-dark' : 'text-light'} />
+          <Col className={'m-auto text-center pb-2'} lg='6'>
             <p className='statement'>The information presented on this site about Magic: The Gathering, both literal and graphical, is copyrighted by Wizards of the Coast (a subsidiary of Hasbro, Inc.), which includes, but is not limited to, card images, the mana symbols, and Oracle text.</p>
             <p className='statement'>This website is not produced, endorsed, supported, or affiliated with Wizards of the Coast.</p>
             <p className='statement'>Nothing on this site constitutes professional and/or financial advice. Always do your own research</p>

--- a/src/components/set/index.css
+++ b/src/components/set/index.css
@@ -73,3 +73,8 @@
     margin: 0 !important;
     font-size: 14px;
 }
+
+.popUpImg {
+    max-height: 150%;
+    width: 150%;
+}

--- a/src/components/set/table.js
+++ b/src/components/set/table.js
@@ -1,16 +1,30 @@
-import { DataGrid, gridNumberComparator } from '@mui/x-data-grid'
+import { DataGrid, gridNumberComparator, gridStringOrNumberComparator } from '@mui/x-data-grid'
 import { Box, Link } from '@mui/material';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
 import './index.css';
 
 function DataTable({ totalSetData }) {
+    const cardNameComparator = (v1, v2) => (v1.name.toLowerCase()).localeCompare((v2.name.toLowerCase()));
+
     const columns = [
         {
             field: 'cardName',
             headerName: 'Card Name',
+            sortComparator: cardNameComparator,
             width: 400,
             renderCell: (params) => (
-                <Link href={params.value.images.normal} target='_blank' color='inherit'>{params.value.name}</Link>
-            )
+                <OverlayTrigger
+                    placement='top'
+                    overlay={
+                        <Tooltip>
+                            <img className='popUpImg' src={params.value.images.normal} />
+                        </Tooltip>
+                    }
+                >
+                    <Link href={params.value.images.normal} target='_blank' color='inherit'>{params.value.name}</Link>
+                </OverlayTrigger>
+            ),
         },
         { field: 'rarity', headerName: 'Rarity', headerAlign: 'right', align: 'right', width: 200 },
         {


### PR DESCRIPTION
used bootstrap's overlay trigger and tooltip to create an image pop-up in the set table when the card name is hovered. fixed the card name sorting.
fixed styling for disclaimer